### PR TITLE
增加灰度插件dubbo演示应用

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 | :---: | :---: | :---: |
 |去源码插件开发模板|[去源码插件开发说明](https://github.com/huaweicloud/Sermant/blob/develop/docs/dev-guide/Sermant去源码插件开发说明.md)|[sermant-test](./sermant-test)|
 |注册插件使用demo|[注册插件使用说明](https://github.com/huaweicloud/Sermant/blob/develop/docs/user-guide/registry/document.md)|[registry-demo](./registry-demo)|
+|灰度插件dubbo示例|[灰度插件说明](https://github.com/huaweicloud/Sermant/blob/develop/docs/user-guide/router/document.md)|[dubbo-router-demo](./router-demo/dubbo-router-demo)|

--- a/router-demo/dubbo-router-demo/deployment/images/consumer/Dockerfile
+++ b/router-demo/dubbo-router-demo/deployment/images/consumer/Dockerfile
@@ -1,0 +1,11 @@
+FROM java:8
+
+WORKDIR /home
+
+COPY dubbo-a.jar /home
+
+COPY start.sh /home
+
+RUN chmod -R 777 /home
+
+ENTRYPOINT ["sh", "/home/start.sh"]

--- a/router-demo/dubbo-router-demo/deployment/images/consumer/build.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/consumer/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash;
+
+version=1.0.0
+name=dubbo-a
+dockerFile=Dockerfile
+imageName=$name:$version
+docker build -f $dockerFile -t $imageName .
+docker push $imageName

--- a/router-demo/dubbo-router-demo/deployment/images/consumer/start.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/consumer/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec java -jar /home/dubbo-a.jar

--- a/router-demo/dubbo-router-demo/deployment/images/provider/Dockerfile
+++ b/router-demo/dubbo-router-demo/deployment/images/provider/Dockerfile
@@ -1,0 +1,11 @@
+FROM java:8
+
+WORKDIR /home
+
+COPY dubbo-b.jar /home
+
+COPY start.sh /home
+
+RUN chmod -R 777 /home
+
+ENTRYPOINT ["sh", "/home/start.sh"]

--- a/router-demo/dubbo-router-demo/deployment/images/provider/build.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/provider/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash;
+
+version=1.0.0
+name=dubbo-b
+dockerFile=Dockerfile
+imageName=$name:$version
+docker build -f $dockerFile -t $imageName .
+docker push $imageName

--- a/router-demo/dubbo-router-demo/deployment/images/provider/start.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/provider/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec java -jar /home/dubbo-b.jar

--- a/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/Dockerfile
+++ b/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/Dockerfile
@@ -1,0 +1,11 @@
+FROM java:8
+
+WORKDIR /home
+
+COPY spring-cloud-gateway.jar /home
+
+COPY start.sh /home
+
+RUN chmod -R 777 /home
+
+ENTRYPOINT ["sh", "/home/start.sh"]

--- a/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/build.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash;
+
+version=1.0.0
+name=spring-cloud-gateway
+dockerFile=Dockerfile
+imageName=$name:$version
+docker build -f $dockerFile -t $imageName .
+docker push $imageName

--- a/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/start.sh
+++ b/router-demo/dubbo-router-demo/deployment/images/spring-cloud-gateway/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec java -jar /home/spring-cloud-gateway.jar

--- a/router-demo/dubbo-router-demo/deployment/k8s/consumer.yaml
+++ b/router-demo/dubbo-router-demo/deployment/k8s/consumer.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dubbo-a
+  labels:
+    app: dubbo-a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dubbo-a
+  template:
+    metadata:
+      labels:
+        app: dubbo-a
+        sermant-injection: enabled
+    spec:
+      containers:
+        - name: dubbo-a
+          image: dubbo-a:1.0.0
+          imagePullPolicy: IfNotPresent
+      imagePullSecrets:
+        - name: default-secret

--- a/router-demo/dubbo-router-demo/deployment/k8s/gray-provider.yaml
+++ b/router-demo/dubbo-router-demo/deployment/k8s/gray-provider.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gray-dubbo-b
+  labels:
+    app: gray-dubbo-b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gray-dubbo-b
+  template:
+    metadata:
+      labels:
+        app: gray-dubbo-b
+        sermant-injection: enabled
+    spec:
+      containers:
+        - name: gray-dubbo-b
+          image: dubbo-b:1.0.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: "SERVICE_META_VERSION"
+              value: "1.0.1"
+      imagePullSecrets:
+        - name: default-secret

--- a/router-demo/dubbo-router-demo/deployment/k8s/provider.yaml
+++ b/router-demo/dubbo-router-demo/deployment/k8s/provider.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dubbo-b
+  labels:
+    app: dubbo-b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dubbo-b
+  template:
+    metadata:
+      labels:
+        app: dubbo-b
+        sermant-injection: enabled
+    spec:
+      containers:
+        - name: dubbo-b
+          image: dubbo-b:1.0.0
+          imagePullPolicy: IfNotPresent
+      imagePullSecrets:
+        - name: default-secret

--- a/router-demo/dubbo-router-demo/deployment/k8s/spring-cloud-getaway.yaml
+++ b/router-demo/dubbo-router-demo/deployment/k8s/spring-cloud-getaway.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring-cloud-gateway
+  labels:
+    app: spring-cloud-gateway
+spec:
+  type: NodePort
+  ports:
+    - port: 28030
+      nodePort: 30000
+      name: spring-cloud-gateway
+  selector:
+    app: spring-cloud-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-cloud-gateway
+  labels:
+    app: spring-cloud-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spring-cloud-gateway
+  template:
+    metadata:
+      labels:
+        app: spring-cloud-gateway
+        sermant-injection: enabled
+    spec:
+      containers:
+        - name: spring-cloud-gateway
+          image: spring-cloud-gateway:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 28030
+      imagePullSecrets:
+        - name: default-secret

--- a/router-demo/dubbo-router-demo/dubbo-a/pom.xml
+++ b/router-demo/dubbo-router-demo/dubbo-a/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-router-demo</artifactId>
+        <groupId>com.huawei.router.demo</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-a</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huawei.router.demo</groupId>
+            <artifactId>dubbo-demo-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/router-demo/dubbo-router-demo/dubbo-a/src/main/java/com/huawei/dubbotest/service/DubboAApplication.java
+++ b/router-demo/dubbo-router-demo/dubbo-a/src/main/java/com/huawei/dubbotest/service/DubboAApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportResource;
+
+@SpringBootApplication(scanBasePackages = {"com.huawei.dubbotest.service","com.huawei.dubbotest.controller"})
+@ImportResource({"classpath:dubbo/provider.xml"})
+public class DubboAApplication {
+    public static void main(String[] args) {
+        System.out.println("====================start=======================");
+        SpringApplication.run(DubboAApplication.class);
+        System.out.println("=====================end========================");
+    }
+}

--- a/router-demo/dubbo-router-demo/dubbo-a/src/main/java/com/huawei/dubbotest/service/imp/ATestImp.java
+++ b/router-demo/dubbo-router-demo/dubbo-a/src/main/java/com/huawei/dubbotest/service/imp/ATestImp.java
@@ -1,0 +1,47 @@
+package com.huawei.dubbotest.service.imp;
+
+import com.huawei.dubbotest.domain.Test;
+import com.huawei.dubbotest.service.ATest;
+import com.huawei.dubbotest.service.BTest;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ATestImp implements ATest {
+
+    @Resource(name = "bTest")
+    private BTest bTest;
+
+    @Override
+    public Map<String, String> testEmpty(long id, String name) {
+        return bTest.testEmpty(id, name);
+    }
+
+    @Override
+    public Map<String, String> testObject(Test test) {
+        return bTest.testObject(test);
+    }
+
+    @Override
+    public Map<String, String> testEnabled(Test test) {
+        return bTest.testEnabled(test);
+    }
+
+    @Override
+    public Map<String, String> testArray(String[] array) {
+        return bTest.testArray(array);
+    }
+
+    @Override
+    public Map<String, String> testList(List<String> list) {
+        return bTest.testList(list);
+    }
+
+    @Override
+    public Map<String, String> testMap(Map<String, String> map) {
+        return bTest.testMap(map);
+    }
+}

--- a/router-demo/dubbo-router-demo/dubbo-a/src/main/resources/application.yaml
+++ b/router-demo/dubbo-router-demo/dubbo-a/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: dubbo-a
+server:
+  port: 28020
+dubbo:
+  application:
+    name: dubbo-a
+  protocol:
+    port: 28820
+    name: dubbo
+  registry:
+    address: sc://127.0.0.1:30100

--- a/router-demo/dubbo-router-demo/dubbo-a/src/main/resources/dubbo/provider.xml
+++ b/router-demo/dubbo-router-demo/dubbo-a/src/main/resources/dubbo/provider.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://code.alibabatech.com/schema/dubbo
+       http://code.alibabatech.com/schema/dubbo/dubbo.xsd">
+
+    <dubbo:application name="dubbo-a"/>
+
+    <!-- use dubbo protocol to export service on port 28820 -->
+    <dubbo:protocol name="dubbo" port="28820"/>
+
+    <dubbo:reference id="bTest" check="false" interface="com.huawei.dubbotest.service.BTest" timeout="30000"/>
+
+    <bean id="aTestImp" class="com.huawei.dubbotest.service.imp.ATestImp"/>
+
+    <dubbo:service interface="com.huawei.dubbotest.service.ATest" ref="ATestImp" timeout="30000"/>
+
+</beans>

--- a/router-demo/dubbo-router-demo/dubbo-b/pom.xml
+++ b/router-demo/dubbo-router-demo/dubbo-b/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-router-demo</artifactId>
+        <groupId>com.huawei.router.demo</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-b</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huawei.router.demo</groupId>
+            <artifactId>dubbo-demo-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/router-demo/dubbo-router-demo/dubbo-b/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
+++ b/router-demo/dubbo-router-demo/dubbo-b/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportResource;
+
+@SpringBootApplication
+@ImportResource({"classpath:dubbo/provider.xml", "classpath*:spring/dubbo-servicecomb.xml"})
+public class DubboBApplication {
+    public static void main(String[] args) {
+        System.out.println("====================start=======================");
+        SpringApplication.run(DubboBApplication.class);
+        System.out.println("=====================end========================");
+    }
+}

--- a/router-demo/dubbo-router-demo/dubbo-b/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
+++ b/router-demo/dubbo-router-demo/dubbo-b/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.service.imp;
+
+import com.huawei.dubbotest.domain.Test;
+import com.huawei.dubbotest.service.BTest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class BTestImp implements BTest {
+    @Value("${service_meta_version:${SERVICE_META_VERSION:${service.meta.version:1.0.0}}}")
+    private String version;
+
+    @Override
+    public Map<String, String> testEmpty(long id, String name) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+
+    @Override
+    public Map<String, String> testObject(Test test) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+
+    @Override
+    public Map<String, String> testEnabled(Test test) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+
+    @Override
+    public Map<String, String> testArray(String[] array) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+
+    @Override
+    public Map<String, String> testList(List<String> list) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+
+    @Override
+    public Map<String, String> testMap(Map<String, String> map1) {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("b", this.version);
+        System.out.println("BTest:============" + map);
+        return map;
+    }
+}

--- a/router-demo/dubbo-router-demo/dubbo-b/src/main/resources/application.yaml
+++ b/router-demo/dubbo-router-demo/dubbo-b/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+server:
+  port: 28022
+dubbo:
+  application:
+    name: dubbo-b
+  protocol:
+    name: dubbo
+    port: 28822
+  registry:
+    address: sc://127.0.0.1:30100
+
+test:
+  version: V1

--- a/router-demo/dubbo-router-demo/dubbo-b/src/main/resources/dubbo/provider.xml
+++ b/router-demo/dubbo-router-demo/dubbo-b/src/main/resources/dubbo/provider.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://code.alibabatech.com/schema/dubbo
+       http://code.alibabatech.com/schema/dubbo/dubbo.xsd">
+
+    <dubbo:application name="dubbo-b"/>
+
+    <!-- use dubbo protocol to export service on port 28822 -->
+    <dubbo:protocol name="dubbo" port="28822"/>
+
+    <!-- service implementation, as same as regular local bean -->
+    <bean id="BTestImp" class="com.huawei.dubbotest.service.imp.BTestImp"/>
+
+    <!-- declare the service interface to be exported -->
+    <dubbo:service interface="com.huawei.dubbotest.service.BTest" ref="BTestImp" timeout="30000"/>
+
+</beans>

--- a/router-demo/dubbo-router-demo/dubbo-demo-common/pom.xml
+++ b/router-demo/dubbo-router-demo/dubbo-demo-common/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-router-demo</artifactId>
+        <groupId>com.huawei.router.demo</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dubbo-demo-common</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+</project>

--- a/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/domain/Test.java
+++ b/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/domain/Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.domain;
+
+import java.io.Serializable;
+
+public class Test implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private long id;
+
+    private String name;
+
+    private boolean enabled;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/ATest.java
+++ b/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/ATest.java
@@ -1,0 +1,20 @@
+package com.huawei.dubbotest.service;
+
+import com.huawei.dubbotest.domain.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ATest {
+    Map<String, String> testEmpty(long id, String name);
+
+    Map<String, String> testObject(Test test);
+
+    Map<String, String> testEnabled(Test test);
+
+    Map<String, String> testArray(String[] array);
+
+    Map<String, String> testList(List<String> list);
+
+    Map<String, String> testMap(Map<String, String> map);
+}

--- a/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/BTest.java
+++ b/router-demo/dubbo-router-demo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/BTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.service;
+
+import com.huawei.dubbotest.domain.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BTest {
+    Map<String, String> testEmpty(long id, String name);
+
+    Map<String, String> testObject(Test test);
+
+    Map<String, String> testEnabled(Test test);
+
+    Map<String, String> testArray(String[] array);
+
+    Map<String, String> testList(List<String> list);
+
+    Map<String, String> testMap(Map<String, String> map);
+}

--- a/router-demo/dubbo-router-demo/pom.xml
+++ b/router-demo/dubbo-router-demo/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.4.RELEASE</version>
+        <relativePath/>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.huawei.router.demo</groupId>
+    <artifactId>dubbo-router-demo</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>dubbo-a</module>
+        <module>dubbo-b</module>
+        <module>dubbo-demo-common</module>
+        <module>spring-cloud-gateway</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <dubbo.version>2.7.5</dubbo.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
+            <version>${dubbo.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/router-demo/dubbo-router-demo/spring-cloud-gateway/pom.xml
+++ b/router-demo/dubbo-router-demo/spring-cloud-gateway/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-router-demo</artifactId>
+        <groupId>com.huawei.router.demo</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-cloud-gateway</artifactId>
+
+    <properties>
+        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+        <spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huawei.router.demo</groupId>
+            <artifactId>dubbo-demo-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/java/com/huawei/dubbotest/GatewayApplication.java
+++ b/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/java/com/huawei/dubbotest/GatewayApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportResource;
+
+@SpringBootApplication(scanBasePackages = {"com.huawei.dubbotest.service","com.huawei.dubbotest.controller"})
+@ImportResource({"classpath:dubbo/consumer.xml"})
+public class GatewayApplication {
+    public static void main(String[] args) {
+        System.out.println("====================start====================");
+        SpringApplication.run(GatewayApplication.class);
+        System.out.println("====================end====================");
+    }
+}

--- a/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/java/com/huawei/dubbotest/controller/DubboController.java
+++ b/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/java/com/huawei/dubbotest/controller/DubboController.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbotest.controller;
+
+import com.huawei.dubbotest.domain.Test;
+import com.huawei.dubbotest.service.ATest;
+import org.apache.dubbo.rpc.RpcContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@RestController
+public class DubboController {
+    @Resource(name = "aTest")
+    private ATest aTest;
+
+    @GetMapping("/empty")
+    public String empty(Long id, String name, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        if (id == null) {
+            id = 0L;
+        }
+        if (name == null) {
+            name = "";
+        }
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testEmpty(id, name));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+
+    @GetMapping("/object")
+    public String object(Test test, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testObject(test));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+
+    @GetMapping("/enabled")
+    public String enabled(Test test, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testEnabled(test));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+
+    @GetMapping("/array")
+    public String array(String name, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        String[] arr = null;
+        if (name != null) {
+            arr = name.split(",");
+        }
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testArray(arr));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+
+    @GetMapping("/list")
+    public String list(String name, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        List<String> list = null;
+        if (name != null) {
+            list = Arrays.asList(name.split(","));
+        }
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testList(list));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+
+    @GetMapping("/map")
+    public String map(@RequestParam Map<String, String> param, @RequestHeader Map<String, String> headers) {
+        RpcContext.getContext().setAttachments(headers);
+        System.out.println("param:" + param);
+        Map<String, String> resultMap = new TreeMap<String, String>();
+        resultMap.put("_dubbo.version", "2.7.5");
+        try {
+            resultMap.putAll(aTest.testMap(param));
+        } catch (Exception e) {
+            resultMap.put("error", e.getMessage());
+        }
+        return resultMap.toString();
+    }
+}

--- a/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/resources/application.yaml
+++ b/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/resources/application.yaml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: gateway
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enable: true
+          lowerCaseServiceIdd: true
+      default-filters:
+        - StripPrefix=1
+
+server:
+  port: 28030
+dubbo:
+  application:
+    name: gateway
+  protocol:
+    name: dubbo
+    port: 28830
+  registry:
+    address: sc://127.0.0.1:30100

--- a/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/resources/dubbo/consumer.xml
+++ b/router-demo/dubbo-router-demo/spring-cloud-gateway/src/main/resources/dubbo/consumer.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:dubbo="http://code.alibabatech.com/schema/dubbo"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://code.alibabatech.com/schema/dubbo
+       http://code.alibabatech.com/schema/dubbo/dubbo.xsd">
+
+    <dubbo:application name="gateway"/>
+
+    <!-- use dubbo protocol to export service on port 28820 -->
+    <dubbo:protocol name="dubbo" port="28830"/>
+
+    <dubbo:reference id="aTest" check="false" interface="com.huawei.dubbotest.service.ATest" timeout="30000"/>
+</beans>

--- a/router-demo/pom.xml
+++ b/router-demo/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.huawei.router.demo</groupId>
+    <artifactId>router-demo</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>dubbo-router-demo</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#5

【修改内容】 增加灰度插件dubbo应用demo

【用例描述】不涉及

【自测情况】

本地测试通过
测试步骤：
1. 本地部署CSE环境
2. dubbo dmeo应用挂载javaagent启动，成功注册到本地CSE
3. 下发灰度规则
4. 调用接口返回正确灰度版本
