### PR TITLE
【fix】fix hystrix's timeout warning for spring cloud router demo

### DIFF
--- a/router-demo/spring-cloud-router-demo/spring-cloud-router-consumer/src/main/resources/application.yml
+++ b/router-demo/spring-cloud-router-demo/spring-cloud-router-consumer/src/main/resources/application.yml
@@ -20,7 +20,7 @@ hystrix:
       execution:
         isolation:
           thread:
-            timeoutInMilliseconds: 10000
+            timeoutInMilliseconds: 50000
 
 ribbon:
   ConnectTimeout: 10000

--- a/router-demo/spring-cloud-router-demo/spring-cloud-router-zuul/src/main/resources/application.yml
+++ b/router-demo/spring-cloud-router-demo/spring-cloud-router-zuul/src/main/resources/application.yml
@@ -20,7 +20,7 @@ hystrix:
       execution:
         isolation:
           thread:
-            timeoutInMilliseconds: 10000
+            timeoutInMilliseconds: 50000
 
 ribbon:
   ConnectTimeout: 10000


### PR DESCRIPTION
【修复issue】 #12 

【修改内容】修改了hystrix超时时间

【用例描述】不涉及

【自测情况】启动spring cloud路由demo，调用下游，没有hystrix相关的超时警告日志

【影响范围】无
