### PR TITLE
first-plugin-demo修改

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -166,3 +166,13 @@ jobs:
           asset_path: ${{ github.workspace }}/package/result/sermant-examples-mq-consume-prohibition-demo-${{ env.version }}.tar.gz
           asset_name: sermant-examples-mq-consume-prohibition-demo-${{ env.version }}.tar.gz
           asset_content_type: application/tar
+      - name: Upload Release first-plugin-demo # first-plugin-demo release包
+        id: upload-release-asset-first-plugin
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/package/result/sermant-examples-first-plugin-demo-${{ env.version }}.tar.gz
+          asset_name: sermant-examples-first-plugin-demo-${{ env.version }}.tar.gz
+          asset_content_type: application/tar

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |        示例名称        |                                         插件文档                                         |                       示例项目                       |
 |:------------------:|:------------------------------------------------------------------------------------:|:------------------------------------------------:|
-|     去源码插件开发模板      |             [去源码插件开发说明](https://sermant.io/zh/document/developer-guide/)             |      [sermant-template](./sermant-template)      |
+|     去源码插件开发模板      |             [去源码插件开发说明](https://sermant.io/zh/document/developer-guide/)             |      [first-plugin-demo](./first-plugin-demo)      |
 |     动态配置插件使用示例     |       [动态配置插件使用说明](https://sermant.io/zh/document/plugin/dynamic-config.html)        |      [flowcontrol-demo](./flowcontrol-demo)      |
 |      流控插件使用示例      |          [流控插件使用说明](https://sermant.io/zh/document/plugin/flowcontrol.html)          |      [flowcontrol-demo](./flowcontrol-demo)      |
 |    无损上下线插件使用示例     |          [无损上下线插件使用说明](https://sermant.io/zh/document/plugin/graceful.html)          |            [grace-demo](./grace-demo)            |
@@ -14,6 +14,7 @@
 | SpringBoot注册插件使用示例 | [SpringBoot注册插件使用说明](https://sermant.io/zh/document/plugin/springboot-registry.html) |         [registry-demo](./registry-demo)         |
 |    服务可见性插件使用示例     |         [服务可见性插件使用说明](https://sermant.io/zh/document/plugin/visibility.html)         |       [visibility-demo](./visibility-demo)       |
 |    离群实例摘除插件使用示例    |          [离群实例摘除插件使用说明](https://sermant.io/zh/document/plugin/removal.html)          |          [removal-demo](./removal-demo)          |
+|    消息队列禁止消费插件使用示例    |          [消息队列禁止消费插件使用说明](https://sermant.io/zh/document/plugin/mq-consume-prohibition.html)  |    [mq-consume-prohibition-demo](./mq-consume-prohibition-demo) |
 
 # RELEASE打包流程
 

--- a/first-plugin-demo/template/template-plugin/src/main/java/com/huaweicloud/sermant/template/TemplateInterceptor.java
+++ b/first-plugin-demo/template/template-plugin/src/main/java/com/huaweicloud/sermant/template/TemplateInterceptor.java
@@ -54,6 +54,15 @@ public class TemplateInterceptor implements Interceptor {
                         System.out.println("插件配置项发生变化，配置项值为：" + event.getContent());
                     }
                 });
+
+        // 用于动态配置演示
+        dynamicConfigService.addConfigListener("demo", "app=default",
+                new DynamicConfigListener() {
+                    @Override
+                    public void process(DynamicConfigEvent event) {
+                        System.out.println("插件配置项发生变化，配置项值为：" + event.getContent());
+                    }
+                });
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
     <modules>
-        <module>sermant-template</module>
+        <module>first-plugin-demo</module>
         <module>registry-demo</module>
         <module>router-demo</module>
         <module>flowcontrol-demo</module>

--- a/scripts/copy_jar.sh
+++ b/scripts/copy_jar.sh
@@ -24,8 +24,11 @@ mkdir -p package/springboot-registry-demo
 mkdir -p package/visibility-demo
 mkdir -p package/removal-demo
 mkdir -p package/mq-consume-prohibition-demo
+mkdir -p package/first-plugin-demo
 
 # 按照文件名模式将对应的jar文件复制到对应目录
+# 创建首个插件
+find . -type d -name "agent" -exec cp -rv {} package/first-plugin-demo/ \;
 # 动态配置
 find . -type f -name "spring-provider.jar" -exec cp -v {} package/dynamic-demo/ \;
 # 流控
@@ -65,6 +68,7 @@ find . -type f -name "rest-provider.jar" -exec cp -v {} package/removal-demo/ \;
 
 
 # 打包
+tar -czvf package/result/sermant-examples-first-plugin-demo-$*.tar.gz -C package/first-plugin-demo/ .
 tar -czvf package/result/sermant-examples-dynamic-demo-$*.tar.gz -C package/dynamic-demo/ .
 tar -czvf package/result/sermant-examples-flowcontrol-demo-$*.tar.gz -C package/flowcontrol-demo/ .
 tar -czvf package/result/sermant-examples-grace-demo-$*.tar.gz -C package/grace-demo/ .


### PR DESCRIPTION
【修复issue】#54

【修改内容】first-plugin-demo增加了动态配置监听器用于动态配置中心使用手册的动态配置演示

【用例描述】不需要

【自测情况】1、本地静态检查通过

【影响范围】动态配置中心使用手册的动态配置演示